### PR TITLE
Scope category chips bar to the content column

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,16 +123,19 @@
   /* ---------- sticky category chips ---------- */
   .chips {
     position: sticky;
-    top: 0;
+    top: 10px;
     z-index: 10;
+    width: min(820px, calc(100% - 40px)); /* stays inside the .wrap content column */
+    margin-inline: auto;
     background: var(--chip-glass);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
-    border-block: 1px solid var(--line);
+    border: 1px solid var(--line);
+    border-radius: 99px;
     display: flex;
     gap: 8px;
     overflow-x: auto;
-    padding: 10px max(20px, calc((100vw - 860px) / 2 + 20px));
+    padding: 8px 14px;
     scrollbar-width: none;
   }
   .chips::-webkit-scrollbar { display: none; }


### PR DESCRIPTION
The sticky category nav spanned the full viewport width, which looked bad on wide screens. It is now a floating rounded bar aligned with the 860px content column (20px side margins on mobile). Verified at 1600px, 1280px, and 375px widths in light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)